### PR TITLE
Prefer smaller series

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -194,7 +194,7 @@ PackageTests()
     rm -rf $testPackageFolder
     mkdir $testPackageFolder
 
-    find $sourceFolder -path $testSearchPattern -exec cp -r -u -T "{}" $testPackageFolder \;
+    find $sourceFolder -path $testSearchPattern -exec cp -r "{}" $testPackageFolder \;
 
     if [ $runtime = "dotnet" ] ; then
         $nuget install NUnit.ConsoleRunner -Version 3.2.0 -Output $testPackageFolder

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,77 @@
+if [ $# -eq 0 ]; then
+  if [ "$TRAVIS_PULL_REQUEST" != false ]; then
+    echo "Need to supply version argument" && exit;
+  fi
+fi
+
+# Use mono or .net depending on OS
+case "$(uname -s)" in
+    CYGWIN*|MINGW32*|MINGW64*|MSYS*)
+        # on windows, use dotnet
+        runtime="dotnet"
+        ;;
+    *)
+        # otherwise use mono
+        runtime="mono"
+        ;;
+esac
+
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  VERSION="$(date +%H:%M:%S)"
+  YEAR="$(date +%Y)"
+  MONTH="$(date +%m)"
+  DAY="$(date +%d)"
+else
+  VERSION=$1
+  BRANCH=$2
+  BRANCH=${BRANCH#refs\/heads\/}
+  BRANCH=${BRANCH//\//-}
+fi
+outputFolder='./_output'
+outputFolderMono='./_output_mono'
+outputFolderOsx='./_output_osx'
+outputFolderOsxApp='./_output_osx_app'
+
+tr -d "\r" < $outputFolderOsxApp/Sonarr.app/Contents/MacOS/Sonarr > $outputFolderOsxApp/Sonarr.app/Contents/MacOS/Sonarr2
+rm $outputFolderOsxApp/Sonarr.app/Contents/MacOS/Sonarr
+chmod +x $outputFolderOsxApp/Sonarr.app/Contents/MacOS/Sonarr2
+mv $outputFolderOsxApp/Sonarr.app/Contents/MacOS/Sonarr2 $outputFolderOsxApp/Sonarr.app/Contents/MacOS/Sonarr >& error.log
+
+if [ $runtime = "dotnet" ] ; then
+  ./7za.exe a Sonarr_Windows_$VERSION.zip ./Sonarr_Windows_$VERSION/*
+  ./7za.exe a -ttar -so Sonarr_Mono_$VERSION.tar ./Sonarr_Mono_$VERSION/* | ./7za.exe a -si Sonarr_Mono_$VERSION.tar.gz
+  ./7za.exe a -ttar -so Sonarr_OSX_$VERSION.tar ./_output_osx/* | ./7za.exe a -si Sonarr_OSX_$VERSION.tar.gz
+  ./7za.exe a -ttar -so Sonarr_OSX_App_$VERSION.tar ./_output_osx_app/* | ./7za.exe a -si Sonarr_OSX_App_$VERSION.tar.gz
+else
+  cp -r $outputFolder/ Sonarr
+  #zip -r Sonarr.$BRANCH.$VERSION.windows.zip Sonarr
+  rm -rf Sonarr
+  cp -r $outputFolderMono/ Sonarr
+  tar -zcvf Sonarr.$BRANCH.linux.tar.gz Sonarr
+  rm -rf Sonarr
+  cp -r $outputFolderOsx/ Sonarr
+  #tar -zcvf Sonarr.$BRANCH.$VERSION.osx.tar.gz Sonarr
+  rm -rf Sonarr
+  #TODO update for tar.gz
+
+  cd _output_osx_app/
+  #zip -r ../Sonarr.$BRANCH.$VERSION.osx-app.zip *
+fi
+# ftp -n ftp.leonardogalli.ch << END_SCRIPT
+# passive
+# quote USER $FTP_USER
+# quote PASS $FTP_PASS
+# mkdir builds
+# cd builds
+# mkdir $YEAR
+# cd $YEAR
+# mkdir $MONTH
+# cd $MONTH
+# mkdir $DAY
+# cd $DAY
+# binary
+# put Sonarr_Windows_$VERSION.zip
+# put Sonarr_Mono_$VERSION.zip
+# put Sonarr_OSX_$VERSION.zip
+# quit
+# END_SCRIPT

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -23,13 +23,13 @@ namespace NzbDrone.Core.DecisionEngine
         {
             var comparers = new List<CompareDelegate>
             {
+                CompareEpisodeCount,
+                CompareSize,
                 CompareQuality,
                 CompareProtocol,
-                CompareEpisodeCount,
                 CompareEpisodeNumber,
                 ComparePeersIfTorrent,
-                CompareAgeIfUsenet,
-                CompareSize
+                CompareAgeIfUsenet
             };
 
             return comparers.Select(comparer => comparer(x, y)).FirstOrDefault(result => result != 0);
@@ -159,7 +159,7 @@ namespace NzbDrone.Core.DecisionEngine
         {
             // TODO: Is smaller better? Smaller for usenet could mean no par2 files.
 
-            return CompareBy(x.RemoteEpisode, y.RemoteEpisode, remoteEpisode => remoteEpisode.Release.Size.Round(200.Megabytes()));
+            return CompareByReverse(x.RemoteEpisode, y.RemoteEpisode, remoteEpisode => remoteEpisode.Release.Size.Round(200.Megabytes()));
         }
     }
 }


### PR DESCRIPTION
Prefers smaller sized downloads over quality and torrent peers; `CompareEpisodeCount` must be moved to the top of the comparison functions list to avoid downloading single episodes when trying to download full seasons.